### PR TITLE
Specify versions for python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-colorama
-sqlalchemy
-flask
-flake8
-nose
-nose-timer
-coverage
-sphinx
+colorama==0.3.9
+sqlalchemy==1.2.0
+flask==0.12.2
+flake8==3.5.0
+nose==1.3.7
+nose-timer==0.7.1
+coverage==4.4.2
+sphinx==1.6.5
 sphinx-rtd-theme==0.1.8


### PR DESCRIPTION
Without them, pip always installs the latest versions of the packages which may
not work with the framework in the future. The specified versions are known to
work correctly.