### PR TITLE
Allow running runner.py from any location

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -15,7 +15,7 @@ import sys
 import time
 
 from regression_tests.cmd_runner import CmdRunner
-from regression_tests.config import parse_config
+from regression_tests.config import parse_standard_config_files
 from regression_tests.db import DB
 from regression_tests.git import Repository
 from regression_tests.io import print_error
@@ -133,7 +133,7 @@ try:
     exit_if_already_running()
 
     # Config.
-    config = parse_config('config.ini', 'config_local.ini')
+    config = parse_standard_config_files()
 
     # Logging.
     setup_logging(config, os.path.basename(__file__))

--- a/daemon.py
+++ b/daemon.py
@@ -15,7 +15,7 @@ import sys
 import time
 
 from regression_tests.cmd_runner import CmdRunner
-from regression_tests.config import parse as parse_config
+from regression_tests.config import parse_config
 from regression_tests.db import DB
 from regression_tests.git import Repository
 from regression_tests.io import print_error

--- a/daemon_windows.py
+++ b/daemon_windows.py
@@ -11,7 +11,7 @@ import sys
 import time
 
 from regression_tests.cmd_runner import CmdRunner
-from regression_tests.config import parse_config
+from regression_tests.config import parse_standard_config_files
 from regression_tests.db import DB
 from regression_tests.git import Repository
 from regression_tests.io import print_error
@@ -86,7 +86,7 @@ exit_if_already_running()
 
 try:
     # Config.
-    config = parse_config('config.ini', 'config_local.ini')
+    config = parse_standard_config_files()
 
     # Logging.
     setup_logging(config, os.path.basename(__file__))

--- a/daemon_windows.py
+++ b/daemon_windows.py
@@ -11,7 +11,7 @@ import sys
 import time
 
 from regression_tests.cmd_runner import CmdRunner
-from regression_tests.config import parse as parse_config
+from regression_tests.config import parse_config
 from regression_tests.db import DB
 from regression_tests.git import Repository
 from regression_tests.io import print_error

--- a/regression_tests/config.py
+++ b/regression_tests/config.py
@@ -5,7 +5,7 @@
 import configparser
 
 
-def parse(*config_files):
+def parse_config(*config_files):
     """Parses the given configuration files and returns the configuration.
 
     Options may be overridden. This allows one to have a global configuration

--- a/regression_tests/config.py
+++ b/regression_tests/config.py
@@ -3,9 +3,10 @@
 """
 
 import configparser
+import os
 
 
-def parse_config(*config_files):
+def parse_config(config_files):
     """Parses the given configuration files and returns the configuration.
 
     Options may be overridden. This allows one to have a global configuration
@@ -18,3 +19,18 @@ def parse_config(*config_files):
     config = configparser.ConfigParser()
     config.read(config_files)
     return config
+
+
+def parse_standard_config_files(include_local=True):
+    """Parses configurations files from the standard location.
+
+    The standard location is the root directory of the framework.
+    """
+    def path_to(config_file):
+        return os.path.join(os.path.dirname(__file__), os.pardir, config_file)
+
+    config_files = ['config.ini']
+    if include_local:
+        config_files.append('config_local.ini')
+
+    return parse_config([path_to(config_file) for config_file in config_files])

--- a/regression_tests/logging.py
+++ b/regression_tests/logging.py
@@ -45,10 +45,11 @@ def _create_log_file_handler(config, script_name):
 
 def _get_log_file_for_script(config, script_name):
     """Returns a path to the log file for the given script."""
-    return os.path.join(
-        config['logging']['logs_dir'],
-        script_name + config['logging']['extension']
-    )
+    logs_dir = config['logging']['logs_dir']
+    if not os.path.isabs(logs_dir):
+        logs_dir = os.path.join(os.path.dirname(__file__), os.pardir, logs_dir)
+
+    return os.path.join(logs_dir, script_name + config['logging']['extension'])
 
 
 def _create_stderr_handler(config):

--- a/regression_tests/web/views.py
+++ b/regression_tests/web/views.py
@@ -8,7 +8,7 @@ from flask import redirect
 from flask import render_template
 from flask import request
 
-from regression_tests.config import parse as parse_config
+from regression_tests.config import parse_config
 from regression_tests.db import DB
 from regression_tests.utils.format import format_age
 from regression_tests.utils.format import format_date

--- a/regression_tests/web/views.py
+++ b/regression_tests/web/views.py
@@ -8,7 +8,7 @@ from flask import redirect
 from flask import render_template
 from flask import request
 
-from regression_tests.config import parse_config
+from regression_tests.config import parse_standard_config_files
 from regression_tests.db import DB
 from regression_tests.utils.format import format_age
 from regression_tests.utils.format import format_date
@@ -37,7 +37,7 @@ def nl2br(eval_ctx, text):
 
 @app.before_request
 def before_request():
-    g.config = parse_config('config.ini', 'config_local.ini')
+    g.config = parse_standard_config_files()
     g.db = DB(g.config['db']['conn_url'])
 
     # Template settings.

--- a/runner.py
+++ b/runner.py
@@ -18,7 +18,7 @@ from datetime import datetime
 
 from regression_tests.clang import setup_clang_bindings
 from regression_tests.cmd_runner import CmdRunner
-from regression_tests.config import parse_config
+from regression_tests.config import parse_standard_config_files
 from regression_tests.db import DB
 from regression_tests.email import prepare_email
 from regression_tests.email import send_email
@@ -563,7 +563,7 @@ try:
     ensure_is_run_from_script_dir()
 
     # Config.
-    config = parse_config('config.ini', 'config_local.ini')
+    config = parse_standard_config_files()
     ensure_all_required_settings_are_set(config)
 
     # Logging.

--- a/runner.py
+++ b/runner.py
@@ -18,7 +18,7 @@ from datetime import datetime
 
 from regression_tests.clang import setup_clang_bindings
 from regression_tests.cmd_runner import CmdRunner
-from regression_tests.config import parse as parse_config
+from regression_tests.config import parse_config
 from regression_tests.db import DB
 from regression_tests.email import prepare_email
 from regression_tests.email import send_email

--- a/runner.py
+++ b/runner.py
@@ -68,20 +68,6 @@ def parse_args():
     return args
 
 
-def ensure_is_run_from_script_dir():
-    """Ensures that the script is run from its directory."""
-    script_dir = os.path.abspath(os.path.dirname(__file__))
-    if os.getcwd() != script_dir:
-        print_error(
-            '{} has to be run from {}, not from {}'.format(
-                os.path.basename(__file__),
-                script_dir,
-                os.getcwd()
-            )
-        )
-        sys.exit(1)
-
-
 def ensure_all_required_settings_are_set(config):
     """Ensures that all required settings in the given configuration are set."""
     # [runner] -> clang_dir
@@ -560,8 +546,6 @@ def request_username_for_repo(repo_url):
 
 
 try:
-    ensure_is_run_from_script_dir()
-
     # Config.
     config = parse_standard_config_files()
     ensure_all_required_settings_are_set(config)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@
 from unittest import mock
 
 from regression_tests.clang import setup_clang_bindings
-from regression_tests.config import parse as parse_config
+from regression_tests.config import parse_config
 
 
 class WithPatching:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@
 from unittest import mock
 
 from regression_tests.clang import setup_clang_bindings
-from regression_tests.config import parse_config
+from regression_tests.config import parse_standard_config_files
 
 
 class WithPatching:
@@ -22,6 +22,6 @@ class WithPatching:
 
 # We need to setup Clang bindings as they are used by tests for parsing of C
 # source code.
-config = parse_config('config.ini', 'config_local.ini')
+config = parse_standard_config_files()
 setup_clang_bindings(config['runner']['clang_dir'])
 del config

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -4,15 +4,15 @@
 
 import unittest
 
-from regression_tests import config
+from regression_tests.config import parse_config
 from tests.utils import TemporaryFile
 
 
-class ParseTests(unittest.TestCase):
-    """Tests for `config.parse()`."""
+class ParseConfigTests(unittest.TestCase):
+    """Tests for `parse_config()`."""
 
     def test_empty_config_is_returned_when_no_files_are_given(self):
-        parsed_config = config.parse()
+        parsed_config = parse_config()
         self.assertEqual(parsed_config.sections(), [])
 
     def test_single_file_is_parsed_correctly(self):
@@ -26,7 +26,7 @@ class ParseTests(unittest.TestCase):
             var2 = value2
         '''
         with TemporaryFile(config_content) as cf:
-            parsed_config = config.parse(cf.path)
+            parsed_config = parse_config(cf.path)
             self.assertEqual(parsed_config.sections(), ['sec1', 'sec2'])
             self.assertEqual(parsed_config['sec1']['var1'], 'value1')
             self.assertEqual(parsed_config['sec2']['var2'], 'value2')
@@ -50,12 +50,12 @@ class ParseTests(unittest.TestCase):
         '''
         with TemporaryFile(global_config_content) as global_cf:
             with TemporaryFile(local_config_content) as local_cf:
-                parsed_config = config.parse(global_cf.path, local_cf.path)
+                parsed_config = parse_config(global_cf.path, local_cf.path)
                 self.assertEqual(parsed_config.sections(), ['sec1', 'sec2'])
                 self.assertEqual(parsed_config['sec1']['var1'], 'value1')
                 self.assertEqual(parsed_config['sec2']['var2'], 'other_value2')
                 self.assertEqual(parsed_config['sec2']['var3'], 'value3')
 
     def test_file_that_cannot_be_read_is_ignored(self):
-        parsed_config = config.parse('/hopefully-non-existing-file.txt')
+        parsed_config = parse_config('/hopefully-non-existing-file.txt')
         self.assertEqual(parsed_config.sections(), [])

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -12,7 +12,7 @@ class ParseConfigTests(unittest.TestCase):
     """Tests for `parse_config()`."""
 
     def test_empty_config_is_returned_when_no_files_are_given(self):
-        parsed_config = parse_config()
+        parsed_config = parse_config([])
         self.assertEqual(parsed_config.sections(), [])
 
     def test_single_file_is_parsed_correctly(self):
@@ -26,7 +26,7 @@ class ParseConfigTests(unittest.TestCase):
             var2 = value2
         '''
         with TemporaryFile(config_content) as cf:
-            parsed_config = parse_config(cf.path)
+            parsed_config = parse_config([cf.path])
             self.assertEqual(parsed_config.sections(), ['sec1', 'sec2'])
             self.assertEqual(parsed_config['sec1']['var1'], 'value1')
             self.assertEqual(parsed_config['sec2']['var2'], 'value2')
@@ -50,12 +50,12 @@ class ParseConfigTests(unittest.TestCase):
         '''
         with TemporaryFile(global_config_content) as global_cf:
             with TemporaryFile(local_config_content) as local_cf:
-                parsed_config = parse_config(global_cf.path, local_cf.path)
+                parsed_config = parse_config([global_cf.path, local_cf.path])
                 self.assertEqual(parsed_config.sections(), ['sec1', 'sec2'])
                 self.assertEqual(parsed_config['sec1']['var1'], 'value1')
                 self.assertEqual(parsed_config['sec2']['var2'], 'other_value2')
                 self.assertEqual(parsed_config['sec2']['var3'], 'value3')
 
     def test_file_that_cannot_be_read_is_ignored(self):
-        parsed_config = parse_config('/hopefully-non-existing-file.txt')
+        parsed_config = parse_config(['/hopefully-non-existing-file.txt'])
         self.assertEqual(parsed_config.sections(), [])

--- a/tests/web/views_tests.py
+++ b/tests/web/views_tests.py
@@ -2,10 +2,10 @@
     Tests for the :mod:`regression_tests.web.views` module.
 """
 
-import configparser
 import unittest
 from unittest import mock
 
+from regression_tests.config import parse_standard_config_files
 from regression_tests.web import app
 
 
@@ -15,13 +15,15 @@ class BaseViewsTests(unittest.TestCase):
     def setUp(self):
         self.app = app.test_client()
 
-        # Patch parse_config() to allow config customization.
-        parse_config_patcher = mock.patch('regression_tests.web.views.parse_config')
+        # Patch parse_standard_config_files() to allow config customization.
+        parse_config_patcher = mock.patch('regression_tests.web.views.parse_standard_config_files')
         self.addCleanup(parse_config_patcher.stop)
-        self.mock_parse_config = parse_config_patcher.start()
-        self.config = configparser.ConfigParser()
-        self.config.read('config.ini')
-        self.mock_parse_config.return_value = self.config
+        self.mock_parse_standard_config_files = parse_config_patcher.start()
+        # Do not parse the local configuration file to ensure that the tests
+        # are run with the same settings, disregarding overrides in the local
+        # configuration file.
+        self.config = parse_standard_config_files(include_local=False)
+        self.mock_parse_standard_config_files.return_value = self.config
 
         # Customize the config by overriding the needed global settings.
         # Use the SQLite :memory: database.


### PR DESCRIPTION
We always need to use absolute paths instead of relative paths. This allows us to run runner.py from any directory, not just the root directory of the framework.